### PR TITLE
[Feat/user] 회원가입 기능, 로그인 기능 추가

### DIFF
--- a/onboarding_assignment/build.gradle
+++ b/onboarding_assignment/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 	implementation 'com.google.code.gson:gson:2.8.8'
 
+	implementation 'io.swagger.core.v3:swagger-annotations:2.2.4'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/application/service/AuthService.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/application/service/AuthService.java
@@ -1,0 +1,45 @@
+package com.example.onboarding_assignment.application.service;
+
+import com.example.onboarding_assignment.domain.model.User;
+import com.example.onboarding_assignment.infrastructure.details.CustomUserDetails;
+import com.example.onboarding_assignment.infrastructure.jwt.JwtTokenizer;
+import com.example.onboarding_assignment.libs.error.exception.CustomAuthenticationException;
+import com.example.onboarding_assignment.presentation.dto.requestDto.LogInRequestDto;
+import org.springframework.security.core.AuthenticationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final AuthenticationManager authenticationManager;
+  private final JwtTokenizer jwtTokenizer;
+
+  public String login(LogInRequestDto logInRequestDto) {
+    try {
+      // AuthenticationManager로 인증 처리
+      Authentication authentication = authenticationManager.authenticate(
+          new UsernamePasswordAuthenticationToken(
+              logInRequestDto.getUsername(),
+              logInRequestDto.getPassword()
+          )
+      );
+
+      // 인증 성공 시 사용자 정보와 역할 추출
+      CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+      String username = customUserDetails.getUsername();
+      String role = customUserDetails.getAuthorities().iterator().next().getAuthority();
+
+      // JWT 생성
+      return jwtTokenizer.generateAccessToken(username, role);
+
+    } catch (AuthenticationException e) {
+      throw new CustomAuthenticationException("로그인 실패: " + e.getMessage());
+    }
+  }
+
+}

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/domain/repository/UserRepository.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/domain/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsByUsernameAndIsDeletedFalse(String username);
 
   Optional<User> findByUsername(String username);
+
+  Optional<User> findByUsernameAndIsDeletedFalse(String username);
 }

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/config/SecurityConfig.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/config/SecurityConfig.java
@@ -1,20 +1,74 @@
 package com.example.onboarding_assignment.infrastructure.config;
 
+import com.example.onboarding_assignment.domain.repository.UserRepository;
+import com.example.onboarding_assignment.infrastructure.details.CustomAuthenticationProvider;
+import com.example.onboarding_assignment.infrastructure.details.CustomUserDetailsService;
+import com.example.onboarding_assignment.infrastructure.jwt.JwtAuthFilter;
+import com.example.onboarding_assignment.infrastructure.jwt.JwtTokenizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final JwtTokenizer jwtTokenizer;
+  private final UserRepository userRepository;
+
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  // CustomUserDetailsService를 Bean으로 등록
+  @Bean
+  public CustomUserDetailsService customUserDetailsService() {
+    return new CustomUserDetailsService(userRepository);
+  }
+
+  @Bean
+  public AuthenticationProvider customAuthenticationProvider() {
+    // CustomAuthenticationProvider 생성 및 반환
+    return new CustomAuthenticationProvider(customUserDetailsService(), passwordEncoder());
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+    return new ProviderManager(customAuthenticationProvider()); // CustomAuthenticationProvider 등록
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    JwtAuthFilter jwtAuthorizationFilter = new JwtAuthFilter(customUserDetailsService(), jwtTokenizer);
+
+    return http
+        .csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화
+        .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+        .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+        .sessionManagement(sm -> sm.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS)) // 세션 비활성화
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/users/signup", "/users/sign", "/swagger/auth/v3/api-docs").permitAll() // 로그인 URL 허용
+            .requestMatchers("/users/modifyRole").hasAuthority("ADMIN") // 사용자 목록조회는 관리자 권한만 가능
+            .anyRequest().authenticated() // 나머지는 인증 필요
+        )
+        .addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class) // JwtAuthorizationFilter 추가
+        .build();
   }
 
 }

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/config/SwaggerConfig.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.example.onboarding_assignment.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "auth, user API",
+        version = "v3",
+        description = "auth, user API 입니다"
+    )
+)
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    // Security Scheme (Bearer Token)
+    SecurityScheme apiKey = new SecurityScheme()
+        .type(SecurityScheme.Type.APIKEY)
+        .in(SecurityScheme.In.HEADER)
+        .name("Authorization");
+
+    SecurityRequirement securityRequirement = new SecurityRequirement()
+        .addList("Bearer Token");
+
+    // OpenAPI 설정 (CORS와 API 보안)
+    return new OpenAPI()
+        .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+        .addSecurityItem(securityRequirement)
+        .addServersItem(new Server().url("/")); // CORS 및 Swagger 서버 경로 설정
+  }
+}

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/details/CustomAuthenticationProvider.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/details/CustomAuthenticationProvider.java
@@ -1,0 +1,39 @@
+package com.example.onboarding_assignment.infrastructure.details;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+  private final CustomUserDetailsService customUserDetailsService; // 사용자 정보를 로드하는 서비스
+  private final PasswordEncoder passwordEncoder; // 비밀번호를 검증하기 위한 인코더
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    String username = authentication.getName(); // 입력된 username
+    String password = authentication.getCredentials().toString(); // 입력된 password
+
+    // 사용자 정보 로드
+    CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
+
+    // 비밀번호 검증
+    if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+      throw new BadCredentialsException("Invalid username or password");
+    }
+
+    // 인증 성공 시 UsernamePasswordAuthenticationToken 반환
+    return new UsernamePasswordAuthenticationToken(userDetails, password, userDetails.getAuthorities());
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+  }
+
+}

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/details/CustomUserDetailsService.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/details/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.example.onboarding_assignment.infrastructure.details;
+
+import com.example.onboarding_assignment.domain.model.User;
+import com.example.onboarding_assignment.domain.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  public CustomUserDetailsService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    User user = userRepository.findByUsernameAndIsDeletedFalse(username)
+        .orElseThrow(() -> new UsernameNotFoundException("Not Found username: " + username));
+
+    return new CustomUserDetails(user);
+  }
+}

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/jwt/JwtAuthFilter.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/jwt/JwtAuthFilter.java
@@ -1,0 +1,54 @@
+package com.example.onboarding_assignment.infrastructure.jwt;
+
+import com.example.onboarding_assignment.infrastructure.details.CustomUserDetails;
+import com.example.onboarding_assignment.infrastructure.details.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+  private final CustomUserDetailsService customUserDetailsService;
+  private final JwtTokenizer jwtTokenizer;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    // JWT 추출 및 검증
+    String token = jwtTokenizer.resolveToken(request);
+    if (token == null || !jwtTokenizer.validateToken(token)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    // JWT에서 사용자 정보 추출
+    String username = jwtTokenizer.getUsernameFromToken(token);
+    String role = jwtTokenizer.getUserRoleFromToken(token);
+
+    // 사용자 정보를 customUserDetails에 로드
+    CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(username);
+    if (!role.equals(userDetails.getRole())) {
+      log.warn("Role 불일치: 기대한 role {}, 실제 role {}", userDetails.getRole(), role);
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      response.getWriter().write("{\"code\": 403, \"message\": \"Role 정보가 일치하지 않습니다\"}");
+      return;
+    }
+
+    // securityContextHolder에 저장
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+        userDetails, null, userDetails.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/jwt/JwtTokenizer.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/infrastructure/jwt/JwtTokenizer.java
@@ -1,66 +1,125 @@
 package com.example.onboarding_assignment.infrastructure.jwt;
 
+import com.example.onboarding_assignment.domain.model.UserRole;
+import com.example.onboarding_assignment.presentation.dto.responseDto.AuthorityDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Slf4j
+@Component
 public class JwtTokenizer {
 
-  // SecretKey를 Base64 기반으로 인코딩하기
-  public String encodeSecretKey(String secretKey) {
-    return Encoders.BASE64.encode(secretKey.getBytes(StandardCharsets.UTF_8));
+  @Value("${service.jwt.access-expiration}")
+  private Long accessExpiration;
+
+  public static final String AUTHORIZATION_ROLE = "userRole";
+
+  private final SecretKey secretKey;
+
+  public JwtTokenizer(@Value("${service.jwt.secret-key}") String secretKey) {
+    this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
   }
 
   // accessToken 발급하기
-  public String generateAccessToken(Map<String, Object> claims,
-      String subject,
-      Date expiration,
-      String base64EncodedSecretKey) {
-    Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey); // Base64형식 Secret Key 문자열을 이용해 Key객체를 얻음
-
+  public String generateAccessToken(String userRole,
+      String username) {
     return Jwts.builder()
-        .setClaims(claims)          // JWT에 포함 시킬 Custom Claims를 추가함 (Custom Claims에는 주로 인증된 사용자와 관련된 정보를 추가)
-        .setSubject(subject)        // JWT에 대한 제목을 추가
+        .claim(AUTHORIZATION_ROLE, "ROLE_" + userRole)          // JWT에 포함 시킬 Claims(role)
+        .setSubject(username)        // JWT에 대한 제목을 추가
         .setIssuedAt(Calendar.getInstance().getTime())   // JWT 발행 일자를 설정, 파라미터 타입은 java.util.Date 타입
-        .setExpiration(expiration)  // JWT의 만료일시를 지정
-        .signWith(key)              // 서명을 위한 Key 객체를 설정
+        .setExpiration(new Date(System.currentTimeMillis() + accessExpiration))  // JWT의 만료일시를 지정
+        .signWith(secretKey)              // 서명을 위한 Key 객체를 설정
         .compact();                 // JWT를 생성하고 직렬화함
   }
 
   // accessToken이 만료되면 새로 발급해줄 refreshToken 생성하기
-  public String generateRefreshToken(String subject, Date expiration, String base64EncodedSecretKey) {
-    Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
-
+  public String generateRefreshToken(String subject, Date expiration) {
     return Jwts.builder()
         .setSubject(subject)
         .setIssuedAt(Calendar.getInstance().getTime())
         .setExpiration(expiration)
-        .signWith(key)
+        .signWith(secretKey)
         .compact();
   }
 
-  // JWT의 서명에 사용할 Secret Key를 생성하기
-  private Key getKeyFromBase64EncodedKey(String base64EncodedSecretKey) {
-    byte[] keyBytes = Decoders.BASE64.decode(base64EncodedSecretKey);  // Base64 형식으로 인코딩된 Secret Key를 디코딩한 후, byte array를 반환
-    Key key = Keys.hmacShaKeyFor(keyBytes);    // key byte array를 기반으로 적절한 HMAC 알고리즘을 적용한 Key 객체를 생성
 
-    return key;
+  public boolean validateToken(String token) {
+    try {
+      // 서명 검증
+      verifySignature(token);
+
+      // JWT 파싱을 통해 클레임을 추출하려고 시도
+      Jwts.parserBuilder()
+          .build()
+          .parseClaimsJws(token);
+      return true;
+    } catch (ExpiredJwtException e) {
+      log.error("JWT token is expired: {}", e.getMessage());
+    } catch (UnsupportedJwtException e) {
+      log.error("JWT token is unsupported: {}", e.getMessage());
+    } catch (MalformedJwtException e) {
+      log.error("JWT token is malformed: {}", e.getMessage());
+    } catch (IllegalArgumentException e) {
+      log.error("JWT token is invalid: {}", e.getMessage());
+    } catch (SignatureException e) {
+      log.error("JWT token signature is invalid: {}", e.getMessage());
+    }
+    return false;
   }
 
-  // 토큰 검증하기
-  public void verifySignature(String jws, String base64EncodedSecretKey) {
-    Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
-
+  // 토큰 서명 검증하기
+  public void verifySignature(String jws) {
     Jwts.parserBuilder()
-        .setSigningKey(key) // 서명에 사용된 Secret Key를 설정
+        .setSigningKey(secretKey) // 서명에 사용된 Secret Key를 설정
         .build()
         .parseClaimsJws(jws); // JWT를 파싱해서 Claims를 얻음
+  }
+
+  // 토큰 추출하기
+  public String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7); // "Bearer " 이후의 토큰 값
+    }
+    return null;
+  }
+
+  // 클레임을 추출하는 메서드
+  public Claims getClaimsFromToken(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(secretKey)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+  }
+
+  // 사용자 이름 추출하기
+  public String getUsernameFromToken(String token) {
+    Claims claims = getClaimsFromToken(token);
+    return claims.getSubject(); // subject가 username
+  }
+
+  // 사용자 역할 추출하기
+  public String getUserRoleFromToken(String token) {
+    Claims claims = getClaimsFromToken(token);
+    return claims.get(AUTHORIZATION_ROLE, String.class); // "role" 클레임을 추출
   }
 
 

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/libs/error/exception/CustomAuthenticationException.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/libs/error/exception/CustomAuthenticationException.java
@@ -1,0 +1,14 @@
+package com.example.onboarding_assignment.libs.error.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class CustomAuthenticationException extends AuthenticationException {
+
+  public CustomAuthenticationException(String message) {
+    super(message);
+  }
+
+  public CustomAuthenticationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/presentation/controller/UserController.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/presentation/controller/UserController.java
@@ -1,9 +1,15 @@
 package com.example.onboarding_assignment.presentation.controller;
 
+import com.example.onboarding_assignment.application.service.AuthService;
 import com.example.onboarding_assignment.application.service.UserService;
-import com.example.onboarding_assignment.domain.model.User;
+import com.example.onboarding_assignment.presentation.dto.requestDto.LogInRequestDto;
 import com.example.onboarding_assignment.presentation.dto.requestDto.SignUpRequestDto;
 import com.example.onboarding_assignment.presentation.dto.responseDto.UserResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,16 +20,35 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/users")
+@Tag(name = "User", description = "유저 관련 API")
 public class UserController {
 
   private final UserService userService;
+  private final AuthService authService;
 
   @PostMapping("/signup")
-  public ResponseEntity<UserResponseDto> createUser(@RequestBody SignUpRequestDto requestDto){
+  @Operation(summary = "회원가입", description = "회원가입입니다.")
+  public ResponseEntity<UserResponseDto> createUser(@RequestBody @Parameter(description = "정보를 입력해주세요")
+  SignUpRequestDto requestDto){
     UserResponseDto user = userService.createUser(requestDto);
     return ResponseEntity.ok(user);
   }
 
+  @PostMapping("/sign")
+  @Operation(summary = "로그인", description = "로그인입니다.")
+  public ResponseEntity<Map<String, String>> login(@RequestBody @Valid @Parameter(description = "정보를 입력해주세요")
+  LogInRequestDto logInRequestDto) {
+    // 로그인 로직
+    String token = authService.login(logInRequestDto);
 
+    // 응답 헤더에 토큰 추가
+    String bearerToken = "Bearer " + token;
+
+    // 응답 바디에 토큰값 반환
+    Map<String, String> responseData = Map.of("token", token);
+
+    // ResponseEntity로 반환
+    return ResponseEntity.ok(responseData);
+  }
 
 }

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/presentation/dto/requestDto/LogInRequestDto.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/presentation/dto/requestDto/LogInRequestDto.java
@@ -1,5 +1,8 @@
 package com.example.onboarding_assignment.presentation.dto.requestDto;
 
+import lombok.Getter;
+
+@Getter
 public class LogInRequestDto {
 
   private String username;

--- a/onboarding_assignment/src/main/java/com/example/onboarding_assignment/presentation/dto/requestDto/SignUpRequestDto.java
+++ b/onboarding_assignment/src/main/java/com/example/onboarding_assignment/presentation/dto/requestDto/SignUpRequestDto.java
@@ -1,23 +1,20 @@
 package com.example.onboarding_assignment.presentation.dto.requestDto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Builder
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class SignUpRequestDto {
 
   private String username;
   private String nickname;
   private String password;
-
-  // public 생성자 추가
-  public SignUpRequestDto(String username, String nickname, String password) {
-    this.username = username;
-    this.nickname = nickname;
-    this.password = password;
-  }
 
 }

--- a/onboarding_assignment/src/main/resources/application.yml
+++ b/onboarding_assignment/src/main/resources/application.yml
@@ -16,10 +16,16 @@ spring:
       username: ${DB_USERNAME}
       password: ${DB_PASSWORD}
 
+service:
+  jwt:
+    access-expiration: 86400000  # 24시간
+    secret-key: ${secret-key}  # Base64로 인코딩된 시크릿 키
+
 logging:
   level:
     com.example.onboarding_assignment: DEBUG
-    com.example.onboarding_assignment.infrastructure.jwt.JwtTokenizer: DEBUG
-    com.example.onboarding_assignment.application.service.AuthService: DEBUG
-    com.example.onboarding_assignment.application.service.UserService: DEBUG
-    com.example.onboarding_assignment.presentation.controller.UserController: DEBUG
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /swagger/auth/v3/api-docs


### PR DESCRIPTION
## 연관된 이슈
Close #3 

## 작업 내역
- 회원가입, 로그인 기능 추가
- 토큰 발급 메서드 작성
- api 테스트 진행

## 테스트 
- [x] api 테스트 진행

## 문제 및 해결
- 로그인 시 403에러 발생
->  security chain filter에서 로그인 url 허용을 안 했기 때문
-> 해결 방법: 로그인 url ("/users/sign") .permitAll에 추가하기

## 다음 진행사항
- 스웨거 테스트 진행

## 테스트 결과
- 회원가입
![image](https://github.com/user-attachments/assets/408b386d-a4a4-4968-b269-c43a483a7943)
METHOD: POST
URL: http://localhost:8080/users/signup
REQUEST BODY:
```
{
	"username": "potato1",
	"password": "12341234",
	"nickname": "gamgam1"
}
```

- 로그인
![image](https://github.com/user-attachments/assets/6e03b15a-f2d4-4b01-8be1-07c2e50232ba)
METHOD: POST
URL: http://localhost:8080/users/sign
REQUEST BODY:
```
{
	"username": "potato1",
	"password": "12341234"
}
```