### PR TITLE
fix: 시크릿키 환경변수 명 _로 변경

### DIFF
--- a/onboarding_assignment/src/main/resources/application.yml
+++ b/onboarding_assignment/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 service:
   jwt:
     access-expiration: 86400000  # 24시간
-    secret-key: ${secret-key}  # Base64로 인코딩된 시크릿 키
+    secret-key: ${secret_key}  # Base64로 인코딩된 시크릿 키
 
 logging:
   level:


### PR DESCRIPTION
## 연관된 이슈
Close #

## 작업 내역
- yml의 secret-key 환경변수명 _언더스코어 사용으로 변경

## 테스트 
- [ ] 테스트 진행

## 문제 및 해결
- echo $secret-key 명령어로 환경변수가 안나
->  Linux 환경 변수에서 -는 변수명에 사용할 수 없는 문자
-> 해결 방법: _언더스코어로 변경하기

## 다음 진행사항

## 테스트 결과